### PR TITLE
Update properties in ActionDefinition.

### DIFF
--- a/src/Invictus.TestLibrary.LogicApps.Model/Definitions/ActionDefinition.cs
+++ b/src/Invictus.TestLibrary.LogicApps.Model/Definitions/ActionDefinition.cs
@@ -18,7 +18,13 @@ namespace Invictus.TestLibrary.LogicApps.Model.Definitions
         public RuntimeConfiguration RuntimeConfiguration { get; set; }
 
         [JsonProperty("trackedProperties")]
-        public Dictionary<string, string> TrackedProperties { get; set; }
+        public dynamic TrackedProperties { get; set; }
+
+        [JsonProperty("actions")]
+        public Dictionary<string, ActionDefinition> Actions { get; set; }
+
+        [JsonProperty("expression")]
+        public Dictionary<string, dynamic> Expressions { get; set; }
     }
 
     public class RuntimeConfiguration


### PR DESCRIPTION
As mentioned in the bug report, the ActionDefinition-class was adjusted to:
- include missing properties (Actions/Expressions)
- Adjust object type of the TrackedProperties-property.

Resolves #17.