### PR TITLE
Chore - update NuGet release with `.LogicApps` suffix

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -84,8 +84,8 @@ stages:
             parameters:
               repositoryName: '$(Repository)'
               releaseNotes: |
-                Install new version via [NuGet](https://www.nuget.org/packages/$(Project)/$(Build.BuildNumber))
+                Install new version via [NuGet](https://www.nuget.org/packages/$(Project).LogicApps/$(Build.BuildNumber))
                 ```shell
-                PM > Install-Package $(Project) --Version $(Build.BuildNumber)
+                PM > Install-Package $(Project).LogicApps --Version $(Build.BuildNumber)
                 ```
           - template: nuget/publish-official-package.yml@templates


### PR DESCRIPTION
We changed the library with a `.LogicApps` suffix but didn't change the NuGet release notes and link with this.
The `$(Project)` variable should not be altered bc the tests and other parts depend on this.