### PR TITLE
Provide support for authentication with access token

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -77,7 +77,7 @@ stages:
           - task: AzureCLI@2
             displayName: 'Get Token for Azure Management API'
             inputs:
-              azureSubscription: XXXX
+              azureSubscription: 'Azure - Codit-Arcus'
               scriptType: pscore
               scriptLocation: inlineScript
               inlineScript: |              

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -82,7 +82,7 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |              
                 $token= & az account get-access-token --resource="https://management.azure.com/" --query accessToken
-                Write-Host "##vso[task.setvariable variable=AzureManagementApiAccessToken]$token"
+                Write-Host "##vso[task.setvariable variable=Azure.ManagementApi.AccessToken]$token"
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -74,6 +74,15 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
+          - task: AzureCLI@2
+            displayName: 'Get Token for Azure Management API'
+            inputs:
+              azureSubscription: XXXX
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |              
+                $token= & az account get-access-token --resource="https://management.azure.com/" --query accessToken
+                Write-Host "##vso[task.setvariable variable=AzureManagementApiAccessToken]$token"
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -77,7 +77,7 @@ stages:
           - task: AzureCLI@2
             displayName: 'Get Token for Azure Management API'
             inputs:
-              azureSubscription: 'Azure - Codit-Arcus'
+              azureSubscription: 'Invictus - Azure'
               scriptType: pscore
               scriptLocation: inlineScript
               inlineScript: |              

--- a/docs/logic-apps/authentication.md
+++ b/docs/logic-apps/authentication.md
@@ -50,7 +50,7 @@ The main purpose of authenticating using a token is to avoid distributing sensit
 
 When using a service principal, you need to provide the following information:
 - **Tenant Id** - Identifier of the Azure AD directory
-- **AccessToken** - The token to be used to authenticate with the Azure Management API
+- **Access Token** - The token to be used to authenticate with the Azure Management API
 
 Here is an example:
 ```csharp

--- a/docs/logic-apps/authentication.md
+++ b/docs/logic-apps/authentication.md
@@ -7,7 +7,7 @@ Before you can start using the Azure Logic App testing features, you need to aut
 As of today, we provide the following authentication scenarios:
 
 - [**Using Service Principal**](#using-a-service-principal)
-- [**Using a AccessToken**](#using-a-AccessToken)
+- [**Using an Access Token**](#using-an-Access-Token)
 
 ## Using a Service Principal
 

--- a/docs/logic-apps/authentication.md
+++ b/docs/logic-apps/authentication.md
@@ -6,10 +6,11 @@ Before you can start using the Azure Logic App testing features, you need to aut
 
 As of today, we provide the following authentication scenarios:
 
+- [**Prerequisites**](#Prerequisites)
 - [**Using Service Principal**](#using-a-service-principal)
 - [**Using an Access Token**](#using-an-Access-Token)
 
-# Prerequisites 
+## Prerequisites 
 
 Before we can authenticate, you'll need to [create an Azure AD application](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) which will be used as your service principle.
 
@@ -43,7 +44,7 @@ using (var logicApp = await LogicAppClient.CreateAsync(resourceGroup, logicAppNa
 }
 ```
 
-## Using a Access Token
+## Using an Access Token
 
 The main purpose of authenticating using a token is to avoid distributing sensitive service principle details. As the testing framework uses the Azure Management API, the `resource` scope when requesting a access token should be set to `https://management.azure.com/`.
 

--- a/docs/logic-apps/authentication.md
+++ b/docs/logic-apps/authentication.md
@@ -7,6 +7,7 @@ Before you can start using the Azure Logic App testing features, you need to aut
 As of today, we provide the following authentication scenarios:
 
 - [**Using Service Principal**](#using-a-service-principal)
+- [**Using a token**](#using-a-token)
 
 ## Using a Service Principal
 
@@ -30,6 +31,33 @@ string resourceGroup = "my-resource-group";
 string logicAppName = "my-logic-app-name";
 
 var authentication = LogicAppAuthentication.UsingServicePrincipal(tenantId, subscriptionId, clientId, clientSecret);
+
+// For the Logic App provider
+var provider = LogicAppsProvider.LocatedAt(resourceGroupName, logicAppName, authentication);
+
+// For the Logic App client
+using (var logicApp = await LogicAppClient.CreateAsync(resourceGroup, logicAppName, authentication))	
+{	
+}
+```
+## Using a Token
+
+The service principal used to request a token will need to have at least [`Logic App Contributor`](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#logic-app-contributor) permissions on all your Azure Logic App instances that you want to test.
+
+The main purpose of authenticating using a token is to avoid distributing sensitive service principle details. More details on requesting a token can be found [here](https://docs.microsoft.com/en-us/rest/api/azure/#acquire-an-access-token). As the testing framework leverages the Azure Management API the `resource` should be set to `https://management.azure.com/`.
+
+When using a service principal, you need to provide the following information:
+- **Tenant Id** - Identifier of the Azure AD directory
+- **AccessToken** - The token to be used to authenticate with the Azure Management API
+
+Here is an example:
+```csharp
+string subscriptionId = "my-subscription-id";
+string accessToken = "my-accessToken";
+string resourceGroup = "my-resource-group";
+string logicAppName = "my-logic-app-name";
+
+var authentication = LogicAppAuthentication.UsingAccessToken(subscriptionId, accessToken);
 
 // For the Logic App provider
 var provider = LogicAppsProvider.LocatedAt(resourceGroupName, logicAppName, authentication);

--- a/docs/logic-apps/authentication.md
+++ b/docs/logic-apps/authentication.md
@@ -7,7 +7,7 @@ Before you can start using the Azure Logic App testing features, you need to aut
 As of today, we provide the following authentication scenarios:
 
 - [**Using Service Principal**](#using-a-service-principal)
-- [**Using a token**](#using-a-token)
+- [**Using a AccessToken**](#using-a-AccessToken)
 
 ## Using a Service Principal
 
@@ -40,7 +40,7 @@ using (var logicApp = await LogicAppClient.CreateAsync(resourceGroup, logicAppNa
 {	
 }
 ```
-## Using a Token
+## Using a AccessToken
 
 The service principal used to request a token will need to have at least [`Logic App Contributor`](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#logic-app-contributor) permissions on all your Azure Logic App instances that you want to test.
 

--- a/docs/logic-apps/authentication.md
+++ b/docs/logic-apps/authentication.md
@@ -42,6 +42,7 @@ using (var logicApp = await LogicAppClient.CreateAsync(resourceGroup, logicAppNa
 {	
 }
 ```
+
 ## Using a Access Token
 
 The main purpose of authenticating using a token is to avoid distributing sensitive service principle details. As the testing framework uses the Azure Management API, the `resource` scope when requesting a access token should be set to `https://management.azure.com/`.

--- a/docs/logic-apps/authentication.md
+++ b/docs/logic-apps/authentication.md
@@ -9,11 +9,13 @@ As of today, we provide the following authentication scenarios:
 - [**Using Service Principal**](#using-a-service-principal)
 - [**Using an Access Token**](#using-an-Access-Token)
 
-## Using a Service Principal
+# Prerequisites 
 
 Before we can authenticate, you'll need to [create an Azure AD application](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) which will be used as your service principle.
 
 The service principal will need to have at least [`Logic App Contributor`](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#logic-app-contributor) permissions on all your Azure Logic App instances that you want to test.
+
+## Using a Service Principal
 
 When using a service principal, you need to provide the following information:
 - **Tenant Id** - Identifier of the Azure AD directory
@@ -40,11 +42,11 @@ using (var logicApp = await LogicAppClient.CreateAsync(resourceGroup, logicAppNa
 {	
 }
 ```
-## Using a AccessToken
+## Using a Access Token
 
-The service principal used to request a token will need to have at least [`Logic App Contributor`](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#logic-app-contributor) permissions on all your Azure Logic App instances that you want to test.
+The main purpose of authenticating using a token is to avoid distributing sensitive service principle details. As the testing framework uses the Azure Management API, the `resource` scope when requesting a access token should be set to `https://management.azure.com/`.
 
-The main purpose of authenticating using a token is to avoid distributing sensitive service principle details. More details on requesting a token can be found [here](https://docs.microsoft.com/en-us/rest/api/azure/#acquire-an-access-token). As the testing framework leverages the Azure Management API the `resource` should be set to `https://management.azure.com/`.
+*More details on requesting a token can be found [here](https://docs.microsoft.com/en-us/rest/api/azure/#acquire-an-access-token).*
 
 When using a service principal, you need to provide the following information:
 - **Tenant Id** - Identifier of the Azure AD directory

--- a/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
+++ b/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
@@ -81,7 +81,7 @@ namespace Invictus.Testing.LogicApps
         }
 
         /// <summary>
-        /// Uses a accessToken to authenticate with Azure.
+        /// Uses an access token to authenticate with Azure.
         /// </summary>
         /// <param name="subscriptionId">The ID that identifies the subscription on Azure.</param>
         /// <param name="accessTokenKey">The token to use to call the Azure management API.</param>

--- a/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
+++ b/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
@@ -84,7 +84,7 @@ namespace Invictus.Testing.LogicApps
         /// Uses an access token to authenticate with Azure.
         /// </summary>
         /// <param name="subscriptionId">The ID that identifies the subscription on Azure.</param>
-        /// <param name="accessTokenKey">The token to use to call the Azure management API.</param>
+        /// <param name="accessTokenKey">The secret key to use to fetch access token from the secret provider. This will be used to call the Azure management API.</param>
         /// <param name="secretProvider">The provider to get the client secret; using the <paramref name="accessTokenKey"/>.</param>
         public static LogicAppAuthentication UsingAccessToken(string subscriptionId, string accessTokenKey, ISecretProvider secretProvider)
         {

--- a/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
+++ b/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
@@ -67,6 +67,20 @@ namespace Invictus.Testing.LogicApps
         }
 
         /// <summary>
+        /// Uses the service principal to authenticate with Azure.
+        /// </summary>
+        /// <param name="subscriptionId">The ID that identifies the subscription on Azure.</param>
+        /// <param name="accessToken">The token to use to call the Azure management API.</param>
+        public static LogicAppAuthentication UsingAccessToken(string subscriptionId, string accessToken)
+        {
+            Guard.NotNullOrWhitespace(subscriptionId, nameof(subscriptionId));
+            Guard.NotNullOrWhitespace(accessToken, nameof(accessToken));
+
+            return new LogicAppAuthentication(
+                () => AuthenticateLogicAppsManagementAsync(subscriptionId, accessToken));
+        }
+
+        /// <summary>
         /// Authenticate with Azure with the previously chosen authentication mechanism.
         /// </summary>
         /// <returns>
@@ -87,6 +101,14 @@ namespace Invictus.Testing.LogicApps
             AuthenticationResult token = await authContext.AcquireTokenAsync("https://management.azure.com/", credential);
 
             return new LogicManagementClient(new TokenCredentials(token.AccessToken))
+            {
+                SubscriptionId = subscriptionId
+            };
+        }
+
+        private static async Task<LogicManagementClient> AuthenticateLogicAppsManagementAsync(string subscriptionId, string accessToken)
+        {
+            return new LogicManagementClient(new TokenCredentials(accessToken))
             {
                 SubscriptionId = subscriptionId
             };

--- a/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
+++ b/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
@@ -126,6 +126,9 @@ namespace Invictus.Testing.LogicApps
 
         private static async Task<LogicManagementClient> AuthenticateLogicAppsManagementAsync(string subscriptionId, string accessToken)
         {
+            Guard.NotNullOrWhitespace(subscriptionId, nameof(subscriptionId));
+            Guard.NotNullOrWhitespace(accessToken, nameof(accessToken));
+
             return new LogicManagementClient(new TokenCredentials(accessToken))
             {
                 SubscriptionId = subscriptionId

--- a/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
+++ b/src/Invictus.Testing.LogicApps/LogicAppAuthentication.cs
@@ -67,7 +67,7 @@ namespace Invictus.Testing.LogicApps
         }
 
         /// <summary>
-        /// Uses the service principal to authenticate with Azure.
+        /// Uses a accessToken to authenticate with Azure.
         /// </summary>
         /// <param name="subscriptionId">The ID that identifies the subscription on Azure.</param>
         /// <param name="accessToken">The token to use to call the Azure management API.</param>
@@ -81,7 +81,7 @@ namespace Invictus.Testing.LogicApps
         }
 
         /// <summary>
-        /// Uses the service principal to authenticate with Azure.
+        /// Uses a accessToken to authenticate with Azure.
         /// </summary>
         /// <param name="subscriptionId">The ID that identifies the subscription on Azure.</param>
         /// <param name="accessTokenKey">The token to use to call the Azure management API.</param>

--- a/src/Invictus.Testing.Tests.Integration/LogicAppAuthenticationTests.cs
+++ b/src/Invictus.Testing.Tests.Integration/LogicAppAuthenticationTests.cs
@@ -49,7 +49,7 @@ namespace Invictus.Testing.Tests.Integration
         {
             // Arrange
             string subscriptionId = Configuration.GetAzureSubscriptionId();
-            string accessToken = Environment.GetEnvironmentVariable("AzureManagementApiAccessToken");
+            string accessToken = Configuration.GetAzureAccessToken();
 
             var authentication = LogicAppAuthentication.UsingAccessToken(subscriptionId, accessToken);
 

--- a/src/Invictus.Testing.Tests.Integration/LogicAppAuthenticationTests.cs
+++ b/src/Invictus.Testing.Tests.Integration/LogicAppAuthenticationTests.cs
@@ -49,18 +49,9 @@ namespace Invictus.Testing.Tests.Integration
         {
             // Arrange
             string subscriptionId = Configuration.GetAzureSubscriptionId();
-            string tenantId = Configuration.GetAzureTenantId();
-            string clientId = Configuration.GetAzureClientId();
-            string clientSecret = Configuration.GetAzureClientSecret();
+            string accessToken = Environment.GetEnvironmentVariable("AzureManagementApiAccessToken");
 
-            string authority = $"https://login.windows.net/{tenantId}";
-
-            var authContext = new AuthenticationContext(authority);
-            var credential = new ClientCredential(clientId, clientSecret);
-
-            AuthenticationResult token = await authContext.AcquireTokenAsync("https://management.azure.com/", credential);
-
-            var authentication = LogicAppAuthentication.UsingAccessToken(subscriptionId, token.AccessToken);
+            var authentication = LogicAppAuthentication.UsingAccessToken(subscriptionId, accessToken);
 
             // Act
             using (LogicManagementClient managementClient = await authentication.AuthenticateAsync())

--- a/src/Invictus.Testing.Tests.Integration/TestConfig.cs
+++ b/src/Invictus.Testing.Tests.Integration/TestConfig.cs
@@ -104,6 +104,14 @@ namespace Invictus.Testing.Tests.Integration
             return GetRequiredValue("Azure:Authentication:ClientSecret");
         }
 
+        /// <summary>
+        /// Gets the access token of the application registered to authenticate with the Azure Logic Apps.
+        /// </summary>
+        public string GetAzureAccessToken()
+        {
+            return GetRequiredValue("Azure:Authentication:AccessToken");
+        }
+
         private string GetRequiredValue(string key)
         {
             string value = _configuration[key];

--- a/src/Invictus.Testing.Tests.Integration/appsettings.json
+++ b/src/Invictus.Testing.Tests.Integration/appsettings.json
@@ -6,7 +6,8 @@
 
     "Authentication": {
       "ClientId": "#{LogicApps.ClientId}#",
-      "ClientSecret": "#{LogicApps.ClientSecret}#"
+      "ClientSecret": "#{LogicApps.ClientSecret}#",
+      "AccessToken": "#{Azure.ManagementApi.AccessToken}#"
     },
 
     "LogicApps": {


### PR DESCRIPTION
As described in #52 it would be good from a security aspect to allow authentication using just a token.
This token can be obtained in different ways but my preferred way would be: 

1. Create -if not already present- a service connection in Azure DevOps
2. Add a step in the pipeline to leverage the service connection to obtain a token for the Azure management API
3. Leverage the token from step '2' to authenticate to the subscription and creating the LogicManagementClient

I'm still checking what the best way to test this change but already wanted to create the PR to create some visibility.