### PR TITLE
Feature - add temporary disabling functionality

### DIFF
--- a/docs/logic-apps/control-single-logicapp.md
+++ b/docs/logic-apps/control-single-logicapp.md
@@ -46,9 +46,11 @@ using (var logicApp = ...)
 }
 ```
 
-### Temporary enable Logic App
+### Temporary enable/disable Logic App
 
-The library allows you to temporary enable a Logic App which makes sure that after the test the Logic App is back to its disabled state.
+The library allows you to temporary enable or disable a Logic App which makes sure that after the test the Logic App is back to its disabled state.
+
+**Enabling**
 
 ```csharp
 using (var logicApp = ...)
@@ -60,6 +62,19 @@ using (var logicApp = ...)
 ```
 
 The Logic App will be disabled when the returned disposable gets disposed.
+
+**Disabling**
+
+```csharp
+using (var logicApp = ...)
+{
+    await using (await logicApp.TemporaryDisableAsync())
+    {
+    }
+}
+```
+
+The Logic App will be enabled when the returned disposable gets disposed.
 
 ### Temporary update Logic App's workflow definition
 

--- a/docs/logic-apps/control-single-logicapp.md
+++ b/docs/logic-apps/control-single-logicapp.md
@@ -16,6 +16,15 @@ The features described here requires the following package:
 
 All the following features uses the `LogicAppClient` which can be created using [an Logic App authentication](/authentication.md).
 
+- [Gets Logic App metadata](#gets-logic-app-metadata)
+- [Gets Logic App trigger URL](#gets-logic-app-trigger-url)
+- [Temporary enable/disable Logic App](#temporary-enabledisable-logic-app)
+- [Temporary update Logic App's workflow definition](#temporary-update-logic-apps-workflow-definition)
+- [Temporary enabling static result on Logic App](#temporary-enabling-static-result-on-logic-app)
+- [Running an Logic App](#running-an-logic-app)
+- [Triggering an Logic App](#triggering-an-logic-app)
+- [Delete an Logic App](#delete-an-logic-app)
+
 ### Gets Logic App metadata
 
 This library allows you to retrieve extra metadata about the logic app, such as the name, the current workflow definition, access endpoint...

--- a/src/Invictus.Testing.LogicApps/LogicAppClient.cs
+++ b/src/Invictus.Testing.LogicApps/LogicAppClient.cs
@@ -125,6 +125,27 @@ namespace Invictus.Testing.LogicApps
         }
 
         /// <summary>
+        /// Temporary disables the current logic app resource on Azure, and enables the logic app after the returned instance gets disposed.
+        /// </summary>
+        /// <returns>
+        ///     An instance to control the removal of the updates.
+        /// </returns>
+        public async Task<IAsyncDisposable> TemporaryDisableAsync()
+        {
+            return await AsyncDisposable.CreateAsync(
+                async () =>
+                {
+                    _logger.LogTrace("Disables (-) the workflow on logic app '{LogicAppName}' in resource group '{ResourceGroup}'", _logicAppName, _resourceGroup);
+                    await _logicManagementClient.Workflows.DisableAsync(_resourceGroup, _logicAppName);
+                },
+                async () =>
+                {
+                    _logger.LogTrace("Enables (+) the workflow on logic app '{LogicAppName}' in resource group '{ResourceGroup}'", _logicAppName, _resourceGroup);
+                    await _logicManagementClient.Workflows.EnableAsync(_resourceGroup, _logicAppName);
+                });
+        }
+
+        /// <summary>
         /// Updates the current JSON logic app definition with the given <paramref name="logicAppDefinition"/>,
         /// and removes this update after the returned instance gets disposed.
         /// </summary>

--- a/src/Invictus.Testing.Tests.Integration/LogicAppClientTests.cs
+++ b/src/Invictus.Testing.Tests.Integration/LogicAppClientTests.cs
@@ -200,6 +200,26 @@ namespace Invictus.Testing.Tests.Integration
         }
 
         [Fact]
+        public async Task TemporaryDisableLogicApp_Succeeds()
+        {
+            // Arrange
+            using (var logicApp = await LogicAppClient.CreateAsync(ResourceGroup, LogicAppMockingName, Authentication, Logger))
+            {
+                // Act
+                await using (await logicApp.TemporaryDisableAsync())
+                {
+                    // Assert
+                    LogicAppMetadata metadata = await logicApp.GetMetadataAsync();
+                    Assert.Equal(LogicAppState.Disabled, metadata.State);
+                }
+                {
+                    LogicAppMetadata metadata = await logicApp.GetMetadataAsync();
+                    Assert.Equal(LogicAppState.Enabled, metadata.State);
+                }
+            }
+        }
+
+        [Fact]
         public async Task TemporaryUpdateLogicApp_WithUpdatedResponse_ReturnsUpdatedResponse()
         {
             // Arrange


### PR DESCRIPTION
Provide the `.TemporaryDisableAsync` functionality to the `LogicAppClient` to control a single Logic App instance.

Closes #58 