### PR TITLE
not automatically converting Logic App action input/output to json

### DIFF
--- a/src/Invictus.Testing.LogicApps/LogicAppsProvider.cs
+++ b/src/Invictus.Testing.LogicApps/LogicAppsProvider.cs
@@ -287,8 +287,8 @@ namespace Invictus.Testing.LogicApps
             var actions = new Collection<LogicAppAction>();
             foreach (WorkflowRunAction workflowRunAction in workflowRunActions)
             {
-                JToken input = await GetHttpJsonStringAsync(workflowRunAction.InputsLink?.Uri);
-                JToken output = await GetHttpJsonStringAsync(workflowRunAction.OutputsLink?.Uri);
+                string input = await GetHttpJsonStringAsync(workflowRunAction.InputsLink?.Uri);
+                string output = await GetHttpJsonStringAsync(workflowRunAction.OutputsLink?.Uri);
                 
                 var action = LogicAppConverter.ToLogicAppAction(workflowRunAction, input, output);
                 actions.Add(action);
@@ -298,12 +298,12 @@ namespace Invictus.Testing.LogicApps
             return actions.AsEnumerable();
         }
 
-        private static async Task<JToken> GetHttpJsonStringAsync(string uri)
+        private static async Task<string> GetHttpJsonStringAsync(string uri)
         {
             if (uri != null)
             {
-                string json = await HttpClient.GetStringAsync(uri);
-                return JToken.Parse(json);
+                string content = await HttpClient.GetStringAsync(uri);
+                return content;
             }
 
             return null;


### PR DESCRIPTION
This PR changes the way Logic App input/output content is treated. 
Instead of automatically converting it to json -which gives exceptions when the content is not in the json format- it is treated as a string

Closes #62 